### PR TITLE
Add token-aware query middleware and Control-Dispatch-Plane v1.1 polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ cli/.venv/bin/python -c "import sys; sys.path.insert(0,'cli'); import notion_cli
 
 - Entry: `cli/mcp_server.py`, registered in `.mcp.json`
 - Server name: `notion-agents`
-- Tools: `list_agents`, `list_workspace_agents`, `sync_registry`, `dump_agent`, `update_agent`, `publish_agent`, `discover_agent`, `register_agent`, `remove_agent`, `get_agent_tools`, `add_agent_mcp_server`, `remove_agent_mcp_server`, `set_agent_model`, `chat_with_agent`, `get_conversation`, `query_database`, `get_agent_triggers`, `get_db_automations`, `grant_resource_access`, `get_dispatchable_items`, `build_dispatch_packet`, `stamp_dispatch_consumed`
+- Tools: `list_agents`, `list_workspace_agents`, `sync_registry`, `dump_agent`, `update_agent`, `publish_agent`, `discover_agent`, `register_agent`, `remove_agent`, `get_agent_tools`, `add_agent_mcp_server`, `remove_agent_mcp_server`, `set_agent_model`, `chat_with_agent`, `get_conversation`, `describe_database`, `query_database`, `get_agent_triggers`, `get_db_automations`, `grant_resource_access`, `get_dispatchable_items`, `build_dispatch_packet`, `stamp_dispatch_consumed`
+- `describe_database(database_id)` returns the schema (property names, types, select/status options). **Always call this before `query_database` if you don't know the exact property names and types.** The filter type key in `query_database` must match the property's actual type (e.g. `status` not `select` for status-type properties). `query_database` auto-corrects common mismatches, but `describe_database` prevents them entirely.
 - `chat_with_agent(agent_name, message, wait=True)` sends a message and returns the agent's response. Requires at least one UI-created thread per agent (programmatic thread creation is not yet supported by Notion's inference backend).
 - `sync_registry` auto-populates `cli/agents.yaml` from the live workspace (additive-only, safe to re-run)
 - See `~/.agents/skills/notion-agent-mcp/SKILL.md` for full API reference

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -67,10 +67,6 @@ def _status(props: dict, key: str = "Status") -> str | None:
     return ((props.get(key, {}) or {}).get("status") or {}).get("name")
 
 
-def _checkbox(props: dict, key: str) -> bool:
-    return bool((props.get(key, {}) or {}).get("checkbox", False))
-
-
 def _url(props: dict, key: str) -> str | None:
     return (props.get(key, {}) or {}).get("url") or None
 
@@ -88,7 +84,7 @@ def _relation_ids(props: dict, key: str) -> list[str]:
 def get_dispatchable_items(client: notion_api.NotionAPIClient | None = None) -> list[dict[str, Any]]:
     """Query Work Items DB for items ready to dispatch.
 
-    Criteria: Dispatch Requested=true, Dispatch Requested Consumed At is empty,
+    Criteria: Dispatch Requested Received At is set, Dispatch Requested Consumed At is empty,
     Status in {Not Started, Prompt Requested}.
     """
     if client is None:
@@ -97,7 +93,7 @@ def get_dispatchable_items(client: notion_api.NotionAPIClient | None = None) -> 
     cfg = get_config()
     filter_payload = {
         "and": [
-            {"property": "Dispatch Requested", "checkbox": {"equals": True}},
+            {"property": "Dispatch Requested Received At", "date": {"is_not_empty": True}},
             {"property": "Dispatch Requested Consumed At", "date": {"is_empty": True}},
             {
                 "or": [
@@ -165,7 +161,7 @@ def build_dispatch_packet(
     item_type = _select(props, "Type") or "Other"
     prompt_notes = _text(props, "Prompt Notes") or None
     github_issue_url = _url(props, "GitHub Issue URL")
-    dispatch_requested = _checkbox(props, "Dispatch Requested")
+    received_at = _date_start(props, "Dispatch Requested Received At")
     consumed_at = _date_start(props, "Dispatch Requested Consumed At")
     existing_run_id = _text(props, "run_id") if "run_id" in props else None
 
@@ -236,9 +232,9 @@ def build_dispatch_packet(
     if existing_run_id:
         errors.append(f"V8: work item already has an active run_id '{existing_run_id}'")
 
-    # V9: Dispatch Requested is true
-    if not dispatch_requested:
-        errors.append("V9: Dispatch Requested is not checked")
+    # V9: Dispatch Requested Received At must be set
+    if not received_at:
+        errors.append("V9: Dispatch Requested Received At is not set")
 
     # V10: not already consumed
     if consumed_at:
@@ -308,7 +304,6 @@ def stamp_dispatch_consumed(
 
     # Update Work Item properties
     properties: dict[str, Any] = {
-        "Dispatch Requested": {"checkbox": False},
         "Dispatch Requested Consumed At": {"date": {"start": now}},
         "Status": {"status": {"name": "In Progress"}},
         "run_id": {"rich_text": [{"type": "text", "text": {"content": run_id}}]},

--- a/cli/lab_auditor.py
+++ b/cli/lab_auditor.py
@@ -254,7 +254,7 @@ def check_lab_loop(
         last_edited = _property_timestamp(page, "Last Edited Time", fallback_field="last_edited_time")
         is_post_epoch = bool(created and created >= MODEL_EPOCH)
 
-        dr = _get_checkbox(props, "Dispatch Requested")
+        drra = _get_date_start(props, "Dispatch Requested Received At")
         drca = _get_date_start(props, "Dispatch Requested Consumed At")
         lrra = _get_date_start(props, "Librarian Request Received At")
         lrca = _get_date_start(props, "Librarian Request Consumed At")
@@ -265,8 +265,8 @@ def check_lab_loop(
         outcome = _get_rich_text(props, "Outcome")
         project_ids = _get_relation_ids(props, "Project")
 
-        if dr and drca:
-            _record(violations, "E.1", "MUST-FIX", name, "Dispatch Requested is true while Dispatch Requested Consumed At is set")
+        if drca and not drra:
+            _record(violations, "E.1", "MUST-FIX", name, "Dispatch Requested Consumed At is set but Dispatch Requested Received At is empty (orphan consume)")
             counters["e1"] += 1
         if lrra and lrca:
             _record(violations, "E.1", "MUST-FIX", name, "Librarian Request Received At is still set after Librarian Request Consumed At was written")
@@ -276,8 +276,8 @@ def check_lab_loop(
             _record(violations, "E.8A", "MUST-FIX", name, "Closed/Normal item is missing Verdict")
             counters["e8a"] += 1
 
-        if status == "Done" and dr:
-            _record(violations, "E.3", "MUST-FIX", name, "Status is Done while Dispatch Requested is still true")
+        if status == "Done" and drra and not drca:
+            _record(violations, "E.3", "MUST-FIX", name, "Status is Done but dispatch was never consumed (Dispatch Requested Received At set, Consumed At empty)")
             counters["e3"] += 1
         if status == "Not Started" and synthesis_complete:
             _record(violations, "E.3", "MUST-FIX", name, "Status is Not Started while Synthesis Complete is true")
@@ -308,8 +308,8 @@ def check_lab_loop(
             counters["e5"] += 1
 
         if is_post_epoch:
-            if dr and not drca:
-                _record(violations, "E.7", "P0", name, "Dispatch Requested is true but Dispatch Requested Consumed At is empty")
+            if drra and not drca:
+                _record(violations, "E.7", "P0", name, "Dispatch Requested Received At is set but Dispatch Requested Consumed At is empty (stalled dispatch)")
                 counters["e7"] += 1
             if lrra and not lrca:
                 _record(violations, "E.7", "P0", name, "Librarian Request Received At exists but Librarian Request Consumed At is empty")

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -56,6 +56,19 @@ mcp = FastMCP(
 _collection_schemas: dict[str, dict[str, str]] = {}  # collection_id -> {prop_id: name}
 _collection_lock = threading.Lock()
 
+# Public API schema cache: db_id -> {prop_name: prop_type}
+_db_schema_cache: dict[str, dict[str, str]] = {}
+_db_schema_cache_time: dict[str, float] = {}
+_db_schema_lock = threading.Lock()
+_DB_SCHEMA_TTL = 300  # seconds — mirrors _AUTH_TTL pattern
+
+# System audit properties suppressed from default output
+_SYSTEM_PROP_TYPES = {"created_time", "last_edited_time", "created_by", "last_edited_by"}
+
+# Relation title cache: page_id -> title string
+_relation_title_cache: dict[str, str] = {}
+_relation_title_lock = threading.Lock()
+
 _auth_cache: tuple[str, str | None] | None = None
 _auth_cache_time: float = 0
 _auth_db_mtime: float = 0   # mtime of Firefox cookies.sqlite at last read
@@ -942,8 +955,249 @@ def _get_notion_api_client() -> notion_api.NotionAPIClient:
     return notion_api.NotionAPIClient(CFG.notion_token)
 
 
-def _format_property_value(prop: dict) -> str:
-    """Extract a readable string from a Notion page property value."""
+def _aggregate_pages(pages: list, schema: dict, show_props: list | None = None) -> str:
+    """Compute per-column statistics from a list of Notion pages.
+
+    Returns a markdown stats block. show_props filters which columns to include.
+    """
+    from collections import Counter
+
+    n = len(pages)
+
+    # Collect raw values per property
+    # prop_data: {name: list of raw prop dicts}
+    prop_data: dict[str, list] = {}
+    for page in pages:
+        for name, val in page.get("properties", {}).items():
+            if show_props and name not in show_props:
+                continue
+            prop_data.setdefault(name, []).append(val)
+
+    # Determine column order
+    if show_props:
+        col_order = [c for c in show_props if c in prop_data]
+    else:
+        # Sort, suppressing system props
+        system_names = {nm for nm, pt in schema.items() if pt in _SYSTEM_PROP_TYPES}
+        col_order = sorted(k for k in prop_data if k not in system_names)
+
+    blocks: list[str] = [f"*{n} pages scanned*\n"]
+
+    for name in col_order:
+        vals = prop_data.get(name, [])
+        ptype = schema.get(name, "")
+        total = len(vals)
+
+        if ptype in ("select", "status"):
+            counter: Counter = Counter()
+            for v in vals:
+                raw = v.get(ptype) or {}
+                label = raw.get("name") if isinstance(raw, dict) else None
+                counter[label or "(empty)"] += 1
+            non_empty = total - counter.get("(empty)", 0)
+            lines = [f"## {name} ({ptype}) — {total} pages"]
+            lines.append("| Value | Count |")
+            lines.append("| --- | --- |")
+            for label, cnt in counter.most_common():
+                lines.append(f"| {label} | {cnt} |")
+            blocks.append("\n".join(lines))
+
+        elif ptype == "multi_select":
+            counter = Counter()
+            empty = 0
+            for v in vals:
+                opts = v.get("multi_select", [])
+                if not opts:
+                    empty += 1
+                for opt in opts:
+                    counter[opt.get("name", "?")] += 1
+            lines = [f"## {name} (multi_select) — {total} pages, {empty} empty"]
+            lines.append("| Value | Count |")
+            lines.append("| --- | --- |")
+            for label, cnt in counter.most_common(20):
+                lines.append(f"| {label} | {cnt} |")
+            blocks.append("\n".join(lines))
+
+        elif ptype == "number":
+            nums = [v.get("number") for v in vals if v.get("number") is not None]
+            non_empty = len(nums)
+            if non_empty == 0:
+                blocks.append(f"## {name} (number) — 0 of {total} non-empty")
+            else:
+                mn = min(nums)
+                mx = max(nums)
+                mean = sum(nums) / non_empty
+                blocks.append(
+                    f"## {name} (number) — {non_empty} of {total} non-empty\n"
+                    f"min: {mn} / mean: {mean:.4g} / max: {mx}"
+                )
+
+        elif ptype == "checkbox":
+            true_count = sum(1 for v in vals if v.get("checkbox"))
+            false_count = total - true_count
+            blocks.append(
+                f"## {name} (checkbox) — {total} pages\n"
+                f"true: {true_count} / false: {false_count}"
+            )
+
+        elif ptype == "date":
+            dates = []
+            for v in vals:
+                d = v.get("date")
+                if d and d.get("start"):
+                    dates.append(d["start"])
+            non_empty = len(dates)
+            if non_empty == 0:
+                blocks.append(f"## {name} (date) — 0 of {total} non-empty")
+            else:
+                blocks.append(
+                    f"## {name} (date) — {non_empty} of {total} non-empty\n"
+                    f"earliest: {min(dates)} / latest: {max(dates)}"
+                )
+
+        elif ptype in ("relation", "people"):
+            non_empty = sum(1 for v in vals if v.get(ptype))
+            blocks.append(f"## {name} ({ptype}) — {non_empty} of {total} non-empty")
+
+        elif ptype in (
+            "title", "rich_text", "url", "email", "phone_number",
+            "created_by", "last_edited_by", "created_time", "last_edited_time",
+            "files", "formula", "rollup", "unique_id", "verification",
+        ):
+            non_empty = 0
+            for v in vals:
+                formatted = _format_property_value(v)
+                if formatted.strip():
+                    non_empty += 1
+            blocks.append(f"## {name} ({ptype}) — {non_empty} of {total} non-empty")
+
+        # skip unknown types silently
+
+    return "\n\n".join(blocks)
+
+
+def _get_db_schema(db_id: str) -> dict[str, str]:
+    """Fetch and cache a database's property name -> type map via the public API."""
+    now = time.monotonic()
+    with _db_schema_lock:
+        if db_id in _db_schema_cache and (now - _db_schema_cache_time.get(db_id, 0)) < _DB_SCHEMA_TTL:
+            return _db_schema_cache[db_id]
+    client = _get_notion_api_client()
+    db = client.retrieve_database(db_id)
+    schema = {
+        name: prop_def["type"]
+        for name, prop_def in db.get("properties", {}).items()
+    }
+    with _db_schema_lock:
+        _db_schema_cache[db_id] = schema
+        _db_schema_cache_time[db_id] = time.monotonic()
+    return schema
+
+
+# Filter type aliases: maps wrong-but-common filter keys to the correct one.
+# e.g. caller uses "select" but the property is actually "status" type.
+_FILTER_TYPE_ALIASES: dict[str, set[str]] = {
+    "select": {"status", "select"},
+    "status": {"status", "select"},
+    "multi_select": {"multi_select"},
+    "checkbox": {"checkbox"},
+    "number": {"number"},
+    "date": {"date", "created_time", "last_edited_time"},
+    "rich_text": {"rich_text", "title", "url", "email", "phone_number"},
+    "title": {"rich_text", "title"},
+}
+
+
+def _fix_filter(
+    filter_obj: dict,
+    schema: dict[str, str],
+    name_map: dict[str, str] | None = None,
+) -> dict:
+    """Auto-correct a single filter condition to match the actual property type.
+
+    Handles the common mistake of using {"property": "Status", "select": {...}}
+    when the property is actually a "status" type (needs {"status": {...}}).
+    Compound filters (and/or) are recursed into.
+    name_map: optional {lower_name: canonical_name} for case-insensitive matching.
+    """
+    # Compound filter
+    if "and" in filter_obj:
+        filter_obj["and"] = [_fix_filter(f, schema, name_map) for f in filter_obj["and"]]
+        return filter_obj
+    if "or" in filter_obj:
+        filter_obj["or"] = [_fix_filter(f, schema, name_map) for f in filter_obj["or"]]
+        return filter_obj
+
+    prop_name = filter_obj.get("property")
+    # Case-insensitive name correction
+    if prop_name and name_map:
+        canonical = name_map.get(prop_name.lower())
+        if canonical:
+            filter_obj["property"] = canonical
+            prop_name = canonical
+
+    if not prop_name or prop_name not in schema:
+        return filter_obj  # Can't fix what we don't know
+
+    actual_type = schema[prop_name]
+
+    # Find which key the caller used as the filter type
+    # (everything except "property" is the filter type key)
+    caller_keys = [k for k in filter_obj if k != "property"]
+    if len(caller_keys) != 1:
+        return filter_obj  # Ambiguous or empty, don't touch
+
+    caller_type = caller_keys[0]
+    if caller_type == actual_type:
+        return filter_obj  # Already correct
+
+    # Check if the caller's type is a known alias for the actual type
+    aliases = _FILTER_TYPE_ALIASES.get(caller_type, set())
+    if actual_type in aliases:
+        # Swap the key: {"select": {"equals": "X"}} -> {"status": {"equals": "X"}}
+        filter_obj[actual_type] = filter_obj.pop(caller_type)
+
+    return filter_obj
+
+
+def _resolve_relation_titles(
+    page_ids: list[str],
+    client: "notion_api.NotionAPIClient",
+) -> dict[str, str]:
+    """Batch-resolve page UUIDs to their title strings. Results are cached."""
+    result: dict[str, str] = {}
+    to_fetch: list[str] = []
+    with _relation_title_lock:
+        for pid in page_ids:
+            if pid in _relation_title_cache:
+                result[pid] = _relation_title_cache[pid]
+            else:
+                to_fetch.append(pid)
+
+    for pid in to_fetch:
+        try:
+            page = client.retrieve_page(pid)
+            props = page.get("properties", {})
+            title = ""
+            for prop_val in props.values():
+                if prop_val.get("type") == "title":
+                    title = "".join(t.get("plain_text", "") for t in prop_val.get("title", []))
+                    break
+            title = title.strip() or pid
+        except Exception:
+            title = pid  # degrade gracefully on access error
+        result[pid] = title
+        with _relation_title_lock:
+            _relation_title_cache[pid] = title
+
+    return result
+
+
+def _format_property_value(prop: dict, client: "notion_api.NotionAPIClient | None" = None) -> str:
+    """Extract a readable string from a Notion page property value.
+
+    client: optional API client used to resolve relation page IDs to titles.
+    """
     ptype = prop.get("type", "")
     if ptype == "title":
         return "".join(t.get("plain_text", "") for t in prop.get("title", []))
@@ -964,6 +1218,10 @@ def _format_property_value(prop: dict) -> str:
         return str(val) if val is not None else ""
     if ptype == "url":
         return prop.get("url") or ""
+    if ptype == "email":
+        return prop.get("email") or ""
+    if ptype == "phone_number":
+        return prop.get("phone_number") or ""
     if ptype == "date":
         d = prop.get("date")
         if not d:
@@ -972,19 +1230,110 @@ def _format_property_value(prop: dict) -> str:
         end = d.get("end")
         return f"{start} → {end}" if end else start
     if ptype == "relation":
-        return f"({len(prop.get('relation', []))} linked)"
+        rels = prop.get("relation", [])
+        if not rels:
+            return ""
+        ids = [r.get("id", "") for r in rels if r.get("id")]
+        if not ids:
+            return ""
+        if client:
+            cap = 10
+            fetch_ids = ids[:cap]
+            titles = _resolve_relation_titles(fetch_ids, client)
+            parts = [titles.get(i, i) for i in fetch_ids]
+            if len(ids) > cap:
+                parts.append(f"(+{len(ids) - cap} more)")
+            return ", ".join(parts)
+        return ", ".join(ids)
+    if ptype == "people":
+        people = prop.get("people", [])
+        if not people:
+            return ""
+        names = []
+        for p in people:
+            names.append(p.get("name", p.get("id", "?")))
+        return ", ".join(names)
     if ptype in ("created_time", "last_edited_time"):
         return prop.get(ptype, "")
     if ptype in ("created_by", "last_edited_by"):
         person = prop.get(ptype, {})
         return person.get("name", person.get("id", ""))
+    if ptype == "files":
+        files = prop.get("files", [])
+        if not files:
+            return ""
+        return ", ".join(f.get("name", f.get("url", "?")) for f in files if isinstance(f, dict))
     if ptype == "formula":
         f = prop.get("formula", {})
         return str(f.get(f.get("type", ""), ""))
     if ptype == "rollup":
         r = prop.get("rollup", {})
         return str(r.get(r.get("type", ""), ""))
+    if ptype == "unique_id":
+        uid = prop.get("unique_id", {})
+        prefix = uid.get("prefix", "")
+        number = uid.get("number", "")
+        return f"{prefix}-{number}" if prefix else str(number)
+    if ptype == "verification":
+        v = prop.get("verification", {})
+        return v.get("state", "") if v else ""
     return str(prop)
+
+
+@mcp.tool()
+def describe_database(database_id: str) -> str:
+    """
+    Show a Notion database's schema: property names, types, and select/status options.
+
+    Call this BEFORE query_database if you don't know the exact property names and
+    types. The output tells you which filter type to use for each property.
+
+    database_id: The database page UUID (dashed or dashless).
+    """
+    db_id = _to_dashed_uuid(database_id)
+    client = _get_notion_api_client()
+    db = client.retrieve_database(db_id)
+
+    # Extract title
+    title_parts = db.get("title", [])
+    title = "".join(t.get("plain_text", "") for t in title_parts) or "(untitled)"
+
+    lines = [f"# {title}", f"ID: {db_id}", ""]
+    lines.append("| Property | Type | Filter key | Options |")
+    lines.append("| --- | --- | --- | --- |")
+
+    for name, prop_def in sorted(db.get("properties", {}).items()):
+        ptype = prop_def["type"]
+        # The filter key is the same as the type for most properties
+        filter_key = ptype
+        options = ""
+
+        if ptype == "select":
+            opts = prop_def.get("select", {}).get("options", [])
+            options = ", ".join(o["name"] for o in opts[:10])
+            if len(opts) > 10:
+                options += f" (+{len(opts) - 10} more)"
+        elif ptype == "status":
+            groups = prop_def.get("status", {}).get("groups", [])
+            all_opts = []
+            for g in groups:
+                all_opts.extend(o["name"] for o in g.get("options", []))
+            options = ", ".join(all_opts[:10])
+        elif ptype == "multi_select":
+            opts = prop_def.get("multi_select", {}).get("options", [])
+            options = ", ".join(o["name"] for o in opts[:10])
+            if len(opts) > 10:
+                options += f" (+{len(opts) - 10} more)"
+
+        lines.append(f"| {name} | {ptype} | `{filter_key}` | {options} |")
+
+    # Cache the schema with timestamp
+    schema = {name: prop_def["type"] for name, prop_def in db.get("properties", {}).items()}
+    with _db_schema_lock:
+        _db_schema_cache[db_id] = schema
+        _db_schema_cache_time[db_id] = time.monotonic()
+
+    return "\n".join(lines)
 
 
 @mcp.tool()
@@ -994,22 +1343,42 @@ def query_database(
     sorts: str = "",
     properties: str = "",
     limit: int = 50,
+    cursor: str = "",
+    aggregate: bool = False,
+    max_tokens: int = 0,
+    sample: bool = False,
 ) -> str:
     """
     Query a Notion database by ID and return rows as a formatted table.
 
-    Bypasses the Notion plugin's broken notion-query-database-view tool
-    by calling the public API directly with a database UUID.
+    Auto-corrects common filter mistakes (e.g. using "select" filter for a "status"
+    property). Property name matching is case-insensitive. System audit columns
+    (created_by, created_time, etc.) are hidden by default — list them explicitly
+    in 'properties' to show them.
 
     database_id: The database page UUID (dashed or dashless), NOT the collection://
-        data source ID. Example: "389645af-0e4f-479e-a910-79b169a99462" for Lab Projects.
-    filter: Optional JSON string with a Notion API filter object. Example:
-        '{"property": "Status", "select": {"equals": "Active"}}'
-    sorts: Optional JSON string with a Notion API sorts array. Example:
-        '[{"property": "Last Activity", "direction": "descending"}]'
-    properties: Comma-separated property names to display. If empty, shows all.
-        Example: "Project Name,Status,Category,Last Activity"
-    limit: Max rows to return (default 50, max 100).
+        data source ID.
+    filter: Optional JSON string with a Notion API filter object. The filter type
+        key MUST match the property's actual type. Use describe_database to check.
+        Example: '{"property": "Status", "status": {"equals": "Active"}}'
+    sorts: Optional JSON string with a Notion API sorts array. Property names must
+        match the database schema (case-insensitive).
+        Example: '[{"property": "Name", "direction": "ascending"}]'
+    properties: Comma-separated property names to display. If empty, shows all
+        non-system properties. Case-insensitive.
+    limit: Max rows to return (default 50, max 100). Ignored when aggregate=True.
+    cursor: Pagination cursor from a previous query_database call with more results.
+        Ignored when aggregate=True.
+    aggregate: If True, fetch up to 200 pages and return per-column statistics
+        (value frequencies, numeric ranges, non-empty counts) instead of a row
+        table. ~90% token savings vs loading all rows. Use for "what values exist?"
+        and "how is data distributed?" questions.
+    max_tokens: If > 0, cap output size to approximately this many tokens
+        (1 token ≈ 4 chars). Rows are dropped from the end if over budget, with a
+        note appended. Has no effect when aggregate=True.
+    sample: If True and rows > 10, show first half + last half of results with an
+        omission separator, revealing data range without dense middle rows. Has no
+        effect when aggregate=True.
     """
     client = _get_notion_api_client()
     db_id = _to_dashed_uuid(database_id)
@@ -1017,12 +1386,58 @@ def query_database(
     filter_obj = json.loads(filter) if filter else None
     sorts_obj = json.loads(sorts) if sorts else None
 
-    # Build query payload
+    # Fetch schema for validation, auto-correction, and case-insensitive matching
+    try:
+        schema = _get_db_schema(db_id)
+    except Exception:
+        schema = {}
+
+    # Build case-insensitive name map: lower -> canonical
+    prop_name_map = {n.lower(): n for n in schema} if schema else {}
+
+    # Auto-correct filter types and property names against actual schema
+    if filter_obj and schema:
+        filter_obj = _fix_filter(filter_obj, schema, prop_name_map)
+
+    # Validate and case-correct sort property names
+    if sorts_obj and schema:
+        for sort_item in sorts_obj:
+            prop = sort_item.get("property", "")
+            if prop:
+                canonical = prop_name_map.get(prop.lower())
+                if canonical:
+                    sort_item["property"] = canonical
+                elif prop not in schema:
+                    available = ", ".join(sorted(schema.keys()))
+                    return (
+                        f"Sort property \"{prop}\" not found in database.\n"
+                        f"Available properties: {available}"
+                    )
+
+    # Normalize show_props to canonical casing
+    show_props: list[str] | None = None
+    if properties:
+        raw = [p.strip() for p in properties.split(",") if p.strip()]
+        show_props = [prop_name_map.get(p.lower(), p) for p in raw]
+
+    # --- Aggregate mode: fetch up to 200 pages, return column statistics ---
+    if aggregate:
+        _AGG_CAP = 200
+        pages = client.query_all(db_id, filter_payload=filter_obj, page_size=100)
+        if len(pages) > _AGG_CAP:
+            pages = pages[:_AGG_CAP]
+        if not pages:
+            return "No results."
+        return _aggregate_pages(pages, schema, show_props)
+
+    # --- Standard row-table mode ---
     payload: dict = {"page_size": min(limit, 100)}
     if filter_obj:
         payload["filter"] = filter_obj
     if sorts_obj:
         payload["sorts"] = sorts_obj
+    if cursor:
+        payload["start_cursor"] = cursor.strip()
 
     result = client._request("POST", f"databases/{db_id}/query", payload)
     pages = result.get("results", [])
@@ -1030,44 +1445,157 @@ def query_database(
     if not pages:
         return "No results."
 
-    # Determine which properties to show
-    show_props = [p.strip() for p in properties.split(",") if p.strip()] if properties else None
+    # Determine which system columns to suppress when no explicit properties given
+    system_names: set[str] = set()
+    if not show_props and schema:
+        system_names = {name for name, ptype in schema.items() if ptype in _SYSTEM_PROP_TYPES}
 
-    # Build table rows
+    # Build table rows — always include page URL for actionability
     rows = []
     for page in pages:
         props = page.get("properties", {})
-        row = {}
+        row = {"_url": page.get("url", page.get("id", ""))}
         for name, val in props.items():
             if show_props and name not in show_props:
                 continue
-            row[name] = _format_property_value(val)
+            if not show_props and name in system_names:
+                continue
+            row[name] = _format_property_value(val, client=client)
         rows.append(row)
 
     if not rows:
         return f"{len(pages)} pages returned but no displayable properties."
 
-    # Get column order: use show_props if specified, else sorted keys from first row
+    # Get column order: always lead with _url, then requested or all props
     if show_props:
-        columns = [c for c in show_props if c in rows[0]]
+        columns = ["_url"] + [c for c in show_props if c in rows[0]]
     else:
-        # Put title-like columns first
-        all_cols = list(rows[0].keys())
-        columns = sorted(all_cols)
+        all_cols = [c for c in rows[0].keys() if c != "_url"]
+        columns = ["_url"] + sorted(all_cols)
+
+    # --- Semantic sampling: head + tail with omission row ---
+    if sample and len(rows) > 10:
+        import math
+        head_n = math.ceil(len(rows) / 2)
+        tail_n = len(rows) - head_n
+        omitted = len(rows) - head_n - tail_n
+        omission_row = {c: "..." for c in columns}
+        omission_row[columns[0]] = f"*({omitted} rows omitted)*"
+        rows = rows[:head_n] + [omission_row] + rows[len(rows) - tail_n:]
 
     # Format as markdown table
     header = "| " + " | ".join(columns) + " |"
     separator = "| " + " | ".join("---" for _ in columns) + " |"
     lines = [header, separator]
+    max_cell = 300
     for row in rows:
-        cells = [row.get(c, "").replace("|", "\\|").replace("\n", " ")[:100] for c in columns]
+        cells = []
+        for c in columns:
+            val = row.get(c, "").replace("|", "\\|").replace("\n", " ")
+            if len(val) > max_cell:
+                val = val[: max_cell - 1] + "…"
+            cells.append(val)
         lines.append("| " + " | ".join(cells) + " |")
 
     total_note = ""
-    if result.get("has_more"):
-        total_note = f"\n\n_Showing {len(pages)} of more results. Use filter or increase limit._"
+    if result.get("has_more") and result.get("next_cursor"):
+        next_cur = result["next_cursor"]
+        total_note = (
+            f"\n\n_Showing {len(pages)} rows. More results exist._\n"
+            f'_Next page: call query\\_database with cursor="{next_cur}"_'
+        )
 
-    return "\n".join(lines) + total_note
+    output = "\n".join(lines) + total_note
+
+    # --- Token budget enforcement ---
+    if max_tokens > 0:
+        budget_chars = max_tokens * 4
+        if len(output) > budget_chars:
+            # Binary-search: drop rows from the end until we fit
+            lo, hi = 0, len(rows)
+            while lo < hi:
+                mid = (lo + hi + 1) // 2
+                candidate_lines = [header, separator]
+                for row in rows[:mid]:
+                    cells = []
+                    for c in columns:
+                        val = row.get(c, "").replace("|", "\\|").replace("\n", " ")
+                        if len(val) > max_cell:
+                            val = val[: max_cell - 1] + "…"
+                        cells.append(val)
+                    candidate_lines.append("| " + " | ".join(cells) + " |")
+                if len("\n".join(candidate_lines)) <= budget_chars:
+                    lo = mid
+                else:
+                    hi = mid - 1
+            shown = lo
+            truncated_lines = [header, separator]
+            for row in rows[:shown]:
+                cells = []
+                for c in columns:
+                    val = row.get(c, "").replace("|", "\\|").replace("\n", " ")
+                    if len(val) > max_cell:
+                        val = val[: max_cell - 1] + "…"
+                    cells.append(val)
+                truncated_lines.append("| " + " | ".join(cells) + " |")
+            budget_note = (
+                f"\n\n> Showing {shown} of {len(rows)} rows "
+                f"(token budget: {max_tokens} tokens — "
+                f"use aggregate=True or narrow with properties= for full coverage)"
+            )
+            output = "\n".join(truncated_lines) + budget_note
+
+    return output
+
+
+@mcp.tool()
+def count_database(
+    database_id: str,
+    filter: str = "",
+    exact: bool = False,
+) -> str:
+    """
+    Count rows in a Notion database, optionally matching a filter.
+
+    Use this for "how many?" and "does X exist?" questions instead of fetching
+    rows with query_database.
+
+    database_id: The database page UUID (dashed or dashless).
+    filter: Optional JSON filter (same format as query_database).
+    exact: If False (default), returns a fast existence check using 1 API call —
+        answers "0 rows", "1 row", or "at least 2 rows". If True, pages through
+        the full database to return an exact count (may make multiple API calls).
+    """
+    client = _get_notion_api_client()
+    db_id = _to_dashed_uuid(database_id)
+
+    filter_obj = json.loads(filter) if filter else None
+
+    # Apply same schema validation and auto-correction as query_database
+    try:
+        schema = _get_db_schema(db_id)
+        prop_name_map = {n.lower(): n for n in schema}
+    except Exception:
+        schema = {}
+        prop_name_map = {}
+
+    if filter_obj and schema:
+        filter_obj = _fix_filter(filter_obj, schema, prop_name_map)
+
+    if not exact:
+        # Fast path: 1 API call, answers existence only
+        result = client.query_database(db_id, filter_payload=filter_obj, page_size=1)
+        count = len(result.get("results", []))
+        if count == 0:
+            return "0 rows match."
+        if result.get("has_more"):
+            return "At least 2 rows match. Use exact=True for a precise count."
+        return "1 row matches."
+
+    # Exact count: page through the full result set
+    pages = client.query_all(db_id, filter_payload=filter_obj)
+    n = len(pages)
+    return f"{n} {'row' if n == 1 else 'rows'} match."
 
 
 @mcp.tool()
@@ -1479,8 +2007,8 @@ def get_dispatchable_items() -> str:
     """
     Find Work Items ready for dispatch by an execution plane.
 
-    Returns items where Dispatch Requested=true, Dispatch Requested Consumed At
-    is empty, and Status is Not Started or Prompt Requested.
+    Returns items where Dispatch Requested Received At is set, Dispatch Requested
+    Consumed At is empty, and Status is Not Started or Prompt Requested.
     """
     client = _get_notion_api_client()
     items = dispatch.get_dispatchable_items(client)
@@ -1538,8 +2066,8 @@ def stamp_dispatch_consumed(work_item_id: str, run_id: str) -> str:
     """
     Mark a Work Item as consumed by an execution plane.
 
-    Sets Dispatch Requested=false, Dispatch Requested Consumed At=now(),
-    Status=In Progress, and writes the run_id for idempotency tracking.
+    Sets Dispatch Requested Consumed At=now(), Status=In Progress, and writes
+    the run_id for idempotency tracking.
     Also creates an audit log entry.
 
     work_item_id: UUID of the Work Item page.

--- a/cli/notion_api.py
+++ b/cli/notion_api.py
@@ -169,6 +169,10 @@ class NotionAPIClient:
                 return results
             cursor = page.get("next_cursor")
 
+    def retrieve_database(self, database_id: str) -> dict[str, Any]:
+        """GET /v1/databases/{id} — returns schema, title, and metadata."""
+        return self._request("GET", f"databases/{database_id}")
+
     def query_database(
         self,
         database_id: str,

--- a/cli/test_dispatch.py
+++ b/cli/test_dispatch.py
@@ -28,7 +28,7 @@ def _make_props(
     environment: str | None = None,
     branch: str = "",
     item_type: str = "Gauntlet",
-    dispatch_requested: bool = True,
+    received_at: str | None = "2026-01-01T00:00:00Z",
     consumed_at: str | None = None,
     run_id: str = "",
     github_url: str = "",
@@ -40,7 +40,10 @@ def _make_props(
         "Objective": {"type": "rich_text", "rich_text": [{"plain_text": objective}]},
         "Kill/Stop Condition": {"type": "rich_text", "rich_text": [{"plain_text": kill_condition}]},
         "Dispatch Via": {"type": "select", "select": {"name": dispatch_via} if dispatch_via else None},
-        "Dispatch Requested": {"type": "checkbox", "checkbox": dispatch_requested},
+        "Dispatch Requested Received At": {
+            "type": "date",
+            "date": {"start": received_at} if received_at else None,
+        },
         "Dispatch Requested Consumed At": {
             "type": "date",
             "date": {"start": consumed_at} if consumed_at else None,
@@ -188,9 +191,9 @@ class TestValidation:
         result = self._build(run_id="existing-run-id")
         assert any("V8" in e for e in result["errors"])
 
-    def test_v9_dispatch_not_requested(self):
-        """V9: Dispatch Requested is false."""
-        result = self._build(dispatch_requested=False)
+    def test_v9_dispatch_received_at_not_set(self):
+        """V9: Dispatch Requested Received At is empty."""
+        result = self._build(received_at=None)
         assert any("V9" in e for e in result["errors"])
 
     def test_v10_already_consumed(self):


### PR DESCRIPTION
- query_database: aggregate mode (per-column stats, up to 200 pages, ~90% token savings)
- query_database: max_tokens budget enforcement with binary-search row truncation
- query_database: sample mode (head+tail with omission separator)
- _aggregate_pages() helper: frequencies, numeric ranges, non-empty counts per column type
- dispatch adapter, contracts, HTTP transport (v1.1)
- lab_auditor, notion_api: normalization and compatibility fixes
- test_dispatch: updated for v1.1 contract